### PR TITLE
[BUGFIX] Record Monitoring #2683

### DIFF
--- a/Classes/AbstractDataHandlerListener.php
+++ b/Classes/AbstractDataHandlerListener.php
@@ -123,6 +123,9 @@ abstract class AbstractDataHandlerListener
         if ($isRecursiveUpdateRequired === false) {
             $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($pageId);
             $indexQueueConfigurationName = $this->configurationAwareRecordService->getIndexingConfigurationName('pages', $pageId, $solrConfiguration);
+            if ($indexQueueConfigurationName === null) {
+                return false;
+            }
             $updateFields = $solrConfiguration->getIndexQueueConfigurationRecursiveUpdateFields($indexQueueConfigurationName);
 
             // Check if no additional fields have been defined and then skip recursive update

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/ConfigurationAwareRecordService.php
@@ -27,7 +27,6 @@ namespace ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
-use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -45,11 +44,11 @@ class ConfigurationAwareRecordService
      * @param string $recordTable Table to read from
      * @param int $recordUid Id of the record
      * @param TypoScriptConfiguration $solrConfiguration
-     * @return string Name of indexing configuration
+     * @return string|null Name of indexing configuration
      */
     public function getIndexingConfigurationName($recordTable, $recordUid, TypoScriptConfiguration $solrConfiguration)
     {
-        $name = $recordTable;
+        $name = null;
         $indexingConfigurations = $solrConfiguration->getEnabledIndexQueueConfigurationNames();
         foreach ($indexingConfigurations as $indexingConfigurationName) {
             if (!$solrConfiguration->getIndexQueueConfigurationIsEnabled($indexingConfigurationName)) {

--- a/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
+++ b/Classes/Domain/Index/Queue/RecordMonitor/Helper/RootPageResolver.php
@@ -301,6 +301,9 @@ class RootPageResolver implements SingletonInterface
         foreach ($allSites as $site) {
             $solrConfiguration = $site->getSolrConfiguration();
             $indexingConfigurationName = $this->recordService->getIndexingConfigurationName($table, $uid, $solrConfiguration);
+            if ($indexingConfigurationName === null) {
+                continue;
+            }
             $observedPageIdsOfSiteRoot = $solrConfiguration->getIndexQueueAdditionalPageIdsByConfigurationName($indexingConfigurationName);
             foreach ($observedPageIdsOfSiteRoot as $observedPageIdOfSiteRoot) {
                 $siteRootByObservedPageIds[$observedPageIdOfSiteRoot][] = $site->getRootPageId();

--- a/Classes/Domain/Site/Site.php
+++ b/Classes/Domain/Site/Site.php
@@ -169,8 +169,10 @@ abstract class Site implements SiteInterface
         // Fetch configuration in order to be able to read initialPagesAdditionalWhereClause
         $solrConfiguration = $this->getSolrConfiguration();
         $indexQueueConfigurationName = $configurationAwareRecordService->getIndexingConfigurationName('pages', $this->rootPage['uid'], $solrConfiguration);
+        if ($indexQueueConfigurationName === null) {
+            return $pageIds;
+        }
         $initialPagesAdditionalWhereClause = $solrConfiguration->getInitialPagesAdditionalWhereClause($indexQueueConfigurationName);
-
         return array_merge($pageIds, $this->pagesRepository->findAllSubPageIdsByRootPage($rootPageId, $maxDepth, $initialPagesAdditionalWhereClause));
     }
 

--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -197,6 +197,9 @@ class Queue
 
             $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($rootPageId);
             $indexingConfiguration = $this->recordService->getIndexingConfigurationName($itemType, $itemUid, $solrConfiguration);
+            if ($indexingConfiguration === null) {
+                continue;
+            }
             $itemInQueueForRootPage = $this->containsItemWithRootPageId($itemType, $itemUid, $rootPageId);
             if ($itemInQueueForRootPage) {
                 // update changed time if that item is in the queue already

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -351,54 +351,63 @@ class RecordMonitor extends AbstractDataHandlerListener
      */
     protected function processRecord($recordTable, $recordPageId, $recordUid, $fields)
     {
-        $configurationPageId = $this->getConfigurationPageId($recordTable, $recordPageId, $recordUid);
-
-        if ($configurationPageId === 0) {
-            // when the monitored record doesn't belong to a solr configured root-page and no alternative
-            // siteroot can be found this is not a relevant record
-            return;
-        }
-
-        $solrConfiguration = $this->getSolrConfigurationFromPageId($configurationPageId);
-        $isMonitoredRecord = $solrConfiguration->getIndexQueueIsMonitoredTable($recordTable);
-
-        if (!$isMonitoredRecord) {
-            // when it is a non monitored record, we can skip it.
-            return;
-        }
-
-        $record = $this->configurationAwareRecordService->getRecord($recordTable, $recordUid, $solrConfiguration);
-
-        if (empty($record)) {
-            // TODO move this part to the garbage collector
-            // check if the item should be removed from the index because it no longer matches the conditions
-            $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
-            return;
-        }
-
-        // Clear existing index queue items to prevent mount point duplicates.
-        // This needs to be done before the overlay handling, because handling an overlay record should
-        // not trigger a deletion.
-        $isTranslation = !empty($record['sys_language_uid']) && $record['sys_language_uid'] !== 0;
-        if ($recordTable === 'pages' && !$isTranslation) {
-            $this->indexQueue->deleteItem('pages', $recordUid);
-        }
-
-        // only update/insert the item if we actually found a record
-        $isLocalizedRecord = $this->tcaService->isLocalizedRecord($recordTable, $record);
-        $recordUid = $this->tcaService->getTranslationOriginalUidIfTranslated($recordTable, $record, $recordUid);
-
-        if ($isLocalizedRecord && !$this->getIsTranslationParentRecordEnabled($recordTable, $recordUid)) {
-            // we have a localized record without a visible parent record. Nothing to do.
-            return;
-        }
-
-        if ($this->tcaService->isEnabledRecord($recordTable, $record)) {
-            $this->indexQueue->updateItem($recordTable, $recordUid);
-        }
-
         if ($recordTable === 'pages') {
-            $this->doPagesPostUpdateOperations($fields, $recordUid);
+            $configurationPageId = $this->getConfigurationPageId($recordTable, $recordPageId, $recordUid);
+            if ($configurationPageId === 0) {
+                return;
+            }
+            $rootPageIds = [$configurationPageId];
+        } else {
+            try {
+                $rootPageIds = $this->rootPageResolver->getResponsibleRootPageIds($recordTable, $recordUid);
+                if (empty($rootPageIds)) {
+                    $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+                    return;
+                }
+            } catch ( \InvalidArgumentException $e) {
+                $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+                return;
+            }
+        }
+        foreach ($rootPageIds as $configurationPageId) {
+            $solrConfiguration = $this->getSolrConfigurationFromPageId($configurationPageId);
+            $isMonitoredRecord = $solrConfiguration->getIndexQueueIsMonitoredTable($recordTable);
+            if (!$isMonitoredRecord) {
+                // when it is a non monitored record, we can skip it.
+                continue;
+            }
+
+            $record = $this->configurationAwareRecordService->getRecord($recordTable, $recordUid, $solrConfiguration);
+            if (empty($record)) {
+                // TODO move this part to the garbage collector
+                // check if the item should be removed from the index because it no longer matches the conditions
+                $this->removeFromIndexAndQueueWhenItemInQueue($recordTable, $recordUid);
+                continue;
+            }
+            // Clear existing index queue items to prevent mount point duplicates.
+            // This needs to be done before the overlay handling, because handling an overlay record should
+            // not trigger a deletion.
+            $isTranslation = !empty($record['sys_language_uid']) && $record['sys_language_uid'] !== 0;
+            if ($recordTable === 'pages' && !$isTranslation) {
+                $this->indexQueue->deleteItem('pages', $recordUid);
+            }
+
+            // only update/insert the item if we actually found a record
+            $isLocalizedRecord = $this->tcaService->isLocalizedRecord($recordTable, $record);
+            $recordUid = $this->tcaService->getTranslationOriginalUidIfTranslated($recordTable, $record, $recordUid);
+
+            if ($isLocalizedRecord && !$this->getIsTranslationParentRecordEnabled($recordTable, $recordUid)) {
+                // we have a localized record without a visible parent record. Nothing to do.
+                continue;
+            }
+
+            if ($this->tcaService->isEnabledRecord($recordTable, $record)) {
+                $this->indexQueue->updateItem($recordTable, $recordUid);
+            }
+
+            if ($recordTable === 'pages') {
+                $this->doPagesPostUpdateOperations($fields, $recordUid);
+            }
         }
     }
 

--- a/Tests/Integration/Domain/Site/Fixtures/can_get_all_pages_from_sites.xml
+++ b/Tests/Integration/Domain/Site/Fixtures/can_get_all_pages_from_sites.xml
@@ -25,4 +25,10 @@
         <uid>30</uid>
         <pid>3</pid>
     </pages>
+    <sys_template>
+        <pid>1</pid>
+        <uid>1</uid>
+        <root>1</root>
+        <config>plugin.tx_solr.index.queue.pages = 1</config>
+    </sys_template>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_get_item_count_by_site.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_get_item_count_by_site.xml
@@ -36,4 +36,10 @@
         <indexed>0</indexed>
         <errors></errors>
     </tx_solr_indexqueue_item>
+    <sys_template>
+        <pid>1</pid>
+        <uid>1</uid>
+        <root>1</root>
+        <config>plugin.tx_solr.index.queue.pages = 1</config>
+    </sys_template>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot_with_additionalWhereClause.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/update_record_outside_siteroot_with_additionalWhereClause.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <sys_template>
+        <uid>1</uid>
+        <pid>1</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    index {
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 2
+                                additionalWhereClause = uid=1
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <!-- sysfolder -->
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <doktype>254</doktype>
+        <is_siteroot>0</is_siteroot>
+    </pages>
+    <!-- other root page -->
+    <pages>
+        <uid>111</uid>
+        <pid>0</pid>
+        <is_siteroot>1</is_siteroot>
+        <doktype>1</doktype>
+    </pages>
+    <sys_template>
+        <uid>2</uid>
+        <pid>111</pid>
+        <root>1</root>
+        <clear>3</clear>
+        <config>
+            <![CDATA[
+                plugin.tx_solr {
+                    enabled = 1
+                    index {
+                        queue {
+                            foo = 1
+                            foo {
+                                additionalPageIds = 2
+                                additionalWhereClause = uid=2
+                                table = tx_fakeextension_domain_model_foo
+                                fields {
+                                    title = title
+                                }
+                            }
+                        }
+                    }
+                }
+            ]]>
+        </config>
+        <sorting>100</sorting>
+    </sys_template>
+    <!-- to records -->
+    <tx_fakeextension_domain_model_foo>
+        <uid>1</uid>
+        <title>testnews</title>
+        <pid>2</pid>
+    </tx_fakeextension_domain_model_foo>
+    <tx_fakeextension_domain_model_foo>
+        <uid>2</uid>
+        <title>testnews2</title>
+        <pid>2</pid>
+    </tx_fakeextension_domain_model_foo>
+</dataset>

--- a/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
+++ b/Tests/Integration/IndexQueue/Initializer/Fixtures/mouted_shared_page_from_multiple_trees_can_be_queued.xml
@@ -141,4 +141,10 @@ There is following scenario:
         <content_from_pid>0</content_from_pid>
         <tsconfig_includes/>
     </pages>
+    <sys_template>
+        <pid>111</pid>
+        <uid>2</uid>
+        <root>1</root>
+        <config>plugin.tx_solr.index.queue.pages = 1</config>
+    </sys_template>
 </dataset>

--- a/Tests/Integration/IndexQueue/RecordMonitorTest.php
+++ b/Tests/Integration/IndexQueue/RecordMonitorTest.php
@@ -731,6 +731,51 @@ class RecordMonitorTest extends IntegrationTest
     }
 
     /**
+     * @return array
+     */
+    public function updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider(): array
+    {
+        return [
+            'record-1' => [
+                'uid' => 1,
+                'root' => 1
+            ],
+            'record-2' => [
+                'uid' => 2,
+                'root' => 111
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider updateRecordOutsideSiteRootWithAdditionalWhereClauseDataProvider
+     * @test
+     */
+    public function updateRecordOutsideSiteRootWithAdditionalWhereClause($uid, $root)
+    {
+        $this->importExtTablesDefinition('fake_extension_table.sql');
+        $GLOBALS['TCA']['tx_fakeextension_domain_model_foo'] = include($this->getFixturePathByName('fake_extension_tca.php'));
+
+        $this->importDataSetFromFixture('update_record_outside_siteroot_with_additionalWhereClause.xml');
+
+        $this->assertEmptyIndexQueue();
+
+        // create faked tce main call data
+        $status = 'update';
+        $table = 'tx_fakeextension_domain_model_foo';
+        $fields = [
+            'title' => 'foo',
+            'pid' => 2
+        ];
+        $this->recordMonitor->processDatamap_afterDatabaseOperations($status, $table, $uid, $fields, $this->dataHandler);
+        $this->assertIndexQueueContainsItemAmount(1);
+        $firstQueueItem = $this->indexQueue->getItem(1);
+        $this->assertSame($uid, $firstQueueItem->getRecordUid());
+        $this->assertSame($root, $firstQueueItem->getRootPageUid());
+
+    }
+
+    /**
      * @test
      */
     public function updateRecordOutsideSiteRoot()


### PR DESCRIPTION
Record Monitoring for multiple Sites loads wrong TypoScript Configuration
so different additionalWhereClauses in TypoScript Configuration do not work

Resolves: #2683

# What this pr does

Please add a description here

# How to test

Please add a testing instruction here

Fixes: #issue (Please create an related issue first and mark it as fixed here with your pr)
